### PR TITLE
fix: add missing options on findOne in _create

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -212,11 +212,11 @@ class Service extends AdapterService {
 
     return promise.then(result => {
       if (result.insertedId) {
-        return this.Model.findOne({ _id: result.insertedId });
+        return this.Model.findOne({ _id: result.insertedId }, options);
       }
 
       if (result.insertedIds) {
-        return Promise.all(Object.values(result.insertedIds).map(_id => this.Model.findOne({ _id })));
+        return Promise.all(Object.values(result.insertedIds).map(_id => this.Model.findOne({ _id }, options)));
       }
 
       return result.ops.length > 1 ? result.ops : result.ops[0];


### PR DESCRIPTION
options are needed to get the transactions/sessions to work. Otherwise the create are done on one session and the find is done on another.

### Summary

(If you have not already please refer to the contributing guideline as [described
here](https://github.com/feathersjs/feathers/blob/master/.github/contributing.md#pull-requests))

- [ ] Tell us about the problem your pull request is solving.
- [ ] Are there any open issues that are related to this?
- [ ] Is this PR dependent on PRs in other repos?

If so, please mention them to keep the conversations linked together.

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Your PR will be reviewed by a core team member and they will work with you to get your changes merged in a timely manner. If merged your PR will automatically be added to the changelog in the next release.

If your changes involve documentation updates please mention that and link the appropriate PR in [feathers-docs](https://github.com/feathersjs/feathers-docs).

Thanks for contributing to Feathers! :heart: